### PR TITLE
Fix ember-getowner-polyfill deprecations

### DIFF
--- a/addon/mixins/reset-scroll.js
+++ b/addon/mixins/reset-scroll.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
-const { $, computed, Mixin } = Ember;
+const { $, computed, getOwner, Mixin } = Ember;
 
 export default Mixin.create({
   fastboot: computed(function() {

--- a/addon/mixins/scroll-operator.js
+++ b/addon/mixins/scroll-operator.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
-const { $, computed, Mixin, run } = Ember;
+const { $, computed, getOwner, Mixin, run } = Ember;
 
 export default Mixin.create({
   _scrollingTimeout: 100,

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "ember-data": "^2.7.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
-    "ember-getowner-polyfill": "1.0.1",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "loader.js": "^4.0.1"
@@ -48,7 +47,8 @@
     "browser history"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6"
+    "ember-cli-babel": "^5.1.6",
+    "ember-getowner-polyfill": "^2.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This fixes the "ember-getowner-polyfill is now a true polyfill" deprecation warning with ember-getowner-polyfill >= 1.1.0.